### PR TITLE
Add gif support

### DIFF
--- a/AdButler/AdButler.xcodeproj/project.pbxproj
+++ b/AdButler/AdButler.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BE420BA925F9862E000F7A12 /* iOSDevCenters+GIF.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE420BA825F9862E000F7A12 /* iOSDevCenters+GIF.swift */; };
 		BE734E4825684E180027CC4D /* Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE734E4725684E180027CC4D /* Encoding.swift */; };
 		BE734E4B256C34A00027CC4D /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE734E4A256C34A00027CC4D /* Data.swift */; };
 		BE7AAB5A23A44994003A32D2 /* ABVASTCompanion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AAB5923A44994003A32D2 /* ABVASTCompanion.swift */; };
@@ -64,6 +65,7 @@
 		BE3BC00B215EC1C00018BF74 /* ABInterstitial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABInterstitial.swift; sourceTree = "<group>"; };
 		BE41D8FE211122BF001B017F /* MRAIDUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MRAIDUtilities.swift; sourceTree = "<group>"; };
 		BE41D90021124E2C001B017F /* MRAIDBrowserWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MRAIDBrowserWindow.swift; sourceTree = "<group>"; };
+		BE420BA825F9862E000F7A12 /* iOSDevCenters+GIF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "iOSDevCenters+GIF.swift"; sourceTree = "<group>"; };
 		BE67929A21431AB1009A1409 /* mraid.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = mraid.js; sourceTree = "<group>"; };
 		BE6792A1215169A7009A1409 /* ABErrorCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABErrorCode.swift; sourceTree = "<group>"; };
 		BE6792A3215176E6009A1409 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 				BE6792A3215176E6009A1409 /* StringExtensions.swift */,
 				BE734E4725684E180027CC4D /* Encoding.swift */,
 				BE734E4A256C34A00027CC4D /* Data.swift */,
+				BE420BA825F9862E000F7A12 /* iOSDevCenters+GIF.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -383,6 +386,7 @@
 				BEA1FE9821CAB96B00152B15 /* StringExtensions.swift in Sources */,
 				BEA1FE9921CAB96B00152B15 /* AdButler.h in Sources */,
 				BE87D93A2536222200039016 /* FrequencyCappingData.swift in Sources */,
+				BE420BA925F9862E000F7A12 /* iOSDevCenters+GIF.swift in Sources */,
 				BEA1FE9A21CAB96B00152B15 /* AdButler.swift in Sources */,
 				BEA1FE9B21CAB96B00152B15 /* ABBanner.swift in Sources */,
 				BE7AAB6023A44BD0003A32D2 /* ABVASTDelegate.swift in Sources */,

--- a/AdButler/AdButler/Extensions/iOSDevCenters+GIF.swift
+++ b/AdButler/AdButler/Extensions/iOSDevCenters+GIF.swift
@@ -1,0 +1,182 @@
+//
+//  iOSDevCenters+GIF.swift
+//  GIF-Swift
+//
+//  Created by iOSDevCenters on 11/12/15.
+//  Copyright © 2016 iOSDevCenters. All rights reserved.
+//
+import Foundation
+import UIKit
+import ImageIO
+// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
+// Consider refactoring the code to use the non-optional operators.
+fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+  switch (lhs, rhs) {
+  case let (l?, r?):
+    return l < r
+  case (nil, _?):
+    return true
+  default:
+    return false
+  }
+}
+
+
+
+extension UIImage {
+    
+    public class func gifImageWithData(_ data: Data) -> UIImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            print("image doesn't exist")
+            return nil
+        }
+        
+        return UIImage.animatedImageWithSource(source)
+    }
+    
+    public class func gifImageWithURL(_ gifUrl:String) -> UIImage? {
+        guard let bundleURL:URL? = URL(string: gifUrl)
+            else {
+                print("image named \"\(gifUrl)\" doesn't exist")
+                return nil
+        }
+        guard let imageData = try? Data(contentsOf: bundleURL!) else {
+            print("image named \"\(gifUrl)\" into NSData")
+            return nil
+        }
+        
+        return gifImageWithData(imageData)
+    }
+    
+    public class func gifImageWithName(_ name: String) -> UIImage? {
+        guard let bundleURL = Bundle.main
+            .url(forResource: name, withExtension: "gif") else {
+                print("SwiftGif: This image named \"\(name)\" does not exist")
+                return nil
+        }
+        guard let imageData = try? Data(contentsOf: bundleURL) else {
+            print("SwiftGif: Cannot turn image named \"\(name)\" into NSData")
+            return nil
+        }
+        
+        return gifImageWithData(imageData)
+    }
+    
+    class func delayForImageAtIndex(_ index: Int, source: CGImageSource!) -> Double {
+        var delay = 0.1
+        
+        let cfProperties = CGImageSourceCopyPropertiesAtIndex(source, index, nil)
+        let gifProperties: CFDictionary = unsafeBitCast(
+            CFDictionaryGetValue(cfProperties,
+                Unmanaged.passUnretained(kCGImagePropertyGIFDictionary).toOpaque()),
+            to: CFDictionary.self)
+        
+        var delayObject: AnyObject = unsafeBitCast(
+            CFDictionaryGetValue(gifProperties,
+                Unmanaged.passUnretained(kCGImagePropertyGIFUnclampedDelayTime).toOpaque()),
+            to: AnyObject.self)
+        if delayObject.doubleValue == 0 {
+            delayObject = unsafeBitCast(CFDictionaryGetValue(gifProperties,
+                Unmanaged.passUnretained(kCGImagePropertyGIFDelayTime).toOpaque()), to: AnyObject.self)
+        }
+        
+        delay = delayObject as! Double
+        
+        if delay < 0.1 {
+            delay = 0.1
+        }
+        
+        return delay
+    }
+    
+    class func gcdForPair(_ a: Int?, _ b: Int?) -> Int {
+        var a = a
+        var b = b
+        if b == nil || a == nil {
+            if b != nil {
+                return b!
+            } else if a != nil {
+                return a!
+            } else {
+                return 0
+            }
+        }
+        
+        if a < b {
+            let c = a
+            a = b
+            b = c
+        }
+        
+        var rest: Int
+        while true {
+            rest = a! % b!
+            
+            if rest == 0 {
+                return b!
+            } else {
+                a = b
+                b = rest
+            }
+        }
+    }
+    
+    class func gcdForArray(_ array: Array<Int>) -> Int {
+        if array.isEmpty {
+            return 1
+        }
+        
+        var gcd = array[0]
+        
+        for val in array {
+            gcd = UIImage.gcdForPair(val, gcd)
+        }
+        
+        return gcd
+    }
+    
+    class func animatedImageWithSource(_ source: CGImageSource) -> UIImage? {
+        let count = CGImageSourceGetCount(source)
+        var images = [CGImage]()
+        var delays = [Int]()
+        
+        for i in 0..<count {
+            if let image = CGImageSourceCreateImageAtIndex(source, i, nil) {
+                images.append(image)
+            }
+            
+            let delaySeconds = UIImage.delayForImageAtIndex(Int(i),
+                source: source)
+            delays.append(Int(delaySeconds * 1000.0)) // Seconds to ms
+        }
+        
+        let duration: Int = {
+            var sum = 0
+            
+            for val: Int in delays {
+                sum += val
+            }
+            
+            return sum
+        }()
+        
+        let gcd = gcdForArray(delays)
+        var frames = [UIImage]()
+        
+        var frame: UIImage
+        var frameCount: Int
+        for i in 0..<count {
+            frame = UIImage(cgImage: images[Int(i)])
+            frameCount = Int(delays[Int(i)] / gcd)
+            
+            for _ in 0..<frameCount {
+                frames.append(frame)
+            }
+        }
+        
+        let animation = UIImage.animatedImage(with: frames,
+            duration: Double(duration) / 1000.0)
+        
+        return animation
+    }
+}

--- a/AdButler/AdButler/Placement+ImageView.swift
+++ b/AdButler/AdButler/Placement+ImageView.swift
@@ -30,7 +30,8 @@ public extension Placement {
             }
             
             DispatchQueue.main.async {
-                let image = UIImage(data: data)
+                let type = httpResponse.allHeaderFields["Content-Type"] as? String
+                let image = type == "image/gif" ? UIImage.gifImageWithData(data) : UIImage(data:data)
                 let imageView = ABImageView(image: image)
                 imageView.contentMode = UIView.ContentMode.scaleAspectFit
                 imageView.backgroundColor = UIColor.white


### PR DESCRIPTION
Adds support for GIFS on top of the UIImage object

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

GIF is not supported by UIImage by default.  So an extension is required.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

To Test: Add a gif ad item to AdButler, and get it as a banner.  Make sure to test regular image ads as well.

(Tested in emulator)


