### PR TITLE
Update vast handler to pass clicks to video player

### DIFF
--- a/AdButler/AdButler/AdViews/ABVideoPlayer.swift
+++ b/AdButler/AdButler/AdViews/ABVideoPlayer.swift
@@ -136,6 +136,22 @@ public class ABVideoPlayer: UIViewController, WKUIDelegate, WKNavigationDelegate
         return
     }
     
+    public func requestURLFromParent(_url url:String) {
+        if(url != nil && !url.starts(with:"about:blank") && url != "https://servedbyadbutler.com/" && url != "http://servedbyadbutler.com/"){
+            NSLog("Requesting URL -- " + url)
+            let browser = MRAIDBrowserWindow()
+            browser.initialize()
+            browser.loadUrl(url)
+            browser.onClose(perform:{() in
+                self.vastDelegate?.onBrowserClosing()
+                MRAIDUtilities.setRootController(self.originalRootController!)
+                self.onClose()
+            })
+            self.vastDelegate?.onBrowserOpening()
+            MRAIDUtilities.setRootController(browser)
+        }
+    }
+    
     public func playVideo(_ url:URL, onClose:@escaping () -> Void){
         self.initialize(onClose:onClose);
         let request:URLRequest = URLRequest(url:url)

--- a/AdButler/AdButler/VAST/ABVASTVideo.swift
+++ b/AdButler/AdButler/VAST/ABVASTVideo.swift
@@ -105,7 +105,11 @@ public class ABVASTVideo : NSObject, WKUIDelegate, WKNavigationDelegate {
     
     public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         // Capture window.open (clickthroughs) and redirect
-        webView.load(navigationAction.request)
+        //webView.load(navigationAction.request)
+        if(navigationAction.request.url != nil) {
+            videoPlayer.requestURLFromParent(_url: navigationAction.request.url!.absoluteString)
+        }
+    
         return nil
     }
     


### PR DESCRIPTION
This will fix a bug where the vast handler was loading a click url in it's own webview, rather than passing it to the video player web view.

**Test plan (required)**

Test that VAST clicks open the browser view with navigation controls.
